### PR TITLE
Fail fast each command when actor in "connecting" state

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -94,7 +94,7 @@ scredis {
     max-concurrent-requests = 30000
 
     # By default you have to wait up to `connect-timeout` when you send a request to Redis
-    # but node is dead. Set this to true if you wan't to fail fast all requests untill
+    # but node is dead. Set this to true if you wan't to fail fast all requests until
     # there is no working connection to the node
     fail-command-on-connecting = false
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -94,7 +94,7 @@ scredis {
     max-concurrent-requests = 30000
 
     # By default you have to wait up to `connect-timeout` when you send a request to Redis
-    # but node is dead. Set this to true if you wan't to fail fast all requests until
+    # but node is not responding. Set this to true if you want to fail fast all requests until
     # there is no working connection to the node
     fail-command-on-connecting = false
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -92,7 +92,12 @@ scredis {
     # influences the memory consumption of scredis. Reducing it too much will impact performance
     # negatively.
     max-concurrent-requests = 30000
-    
+
+    # By default you have to wait up to `connect-timeout` when you send a request to Redis
+    # but node is dead. Set this to true if you wan't to fail fast all requests untill
+    # there is no working connection to the node
+    fail-command-on-connecting = false
+
     # Configures the buffer pool used to encode requests.
     # The pool reduces garbage collection overhead.
     encode-buffer-pool {

--- a/src/main/scala/scredis/BlockingClient.scala
+++ b/src/main/scala/scredis/BlockingClient.scala
@@ -47,7 +47,8 @@ class BlockingClient(
   tcpReceiveBufferSizeHint: Int = RedisConfigDefaults.IO.TCPReceiveBufferSizeHint,
   akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
   akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-  akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+  akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+  failCommandOnConnecting: Boolean =  RedisConfigDefaults.Global.FailCommandOnConnecting
 )(implicit system: ActorSystem) extends AkkaBlockingConnection(
   system = system,
   host = host,
@@ -62,7 +63,8 @@ class BlockingClient(
   decodersCount = 2,
   akkaListenerDispatcherPath = akkaListenerDispatcherPath,
   akkaIODispatcherPath = akkaIODispatcherPath,
-  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+  failCommandOnConnecting = failCommandOnConnecting
 ) with BlockingListCommands {
   
   /**
@@ -83,7 +85,9 @@ class BlockingClient(
     tcpReceiveBufferSizeHint = config.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath = config.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath = config.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting = config.Global.FailCommandOnConnecting
+
   )
   
   /**
@@ -203,7 +207,8 @@ object BlockingClient {
     tcpReceiveBufferSizeHint: Int = RedisConfigDefaults.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting: Boolean =  RedisConfigDefaults.Global.FailCommandOnConnecting
   )(implicit system: ActorSystem): BlockingClient = new BlockingClient(
     host = host,
     port = port,
@@ -216,7 +221,8 @@ object BlockingClient {
     tcpReceiveBufferSizeHint = tcpReceiveBufferSizeHint,
     akkaListenerDispatcherPath = akkaListenerDispatcherPath,
     akkaIODispatcherPath = akkaIODispatcherPath,
-    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+    failCommandOnConnecting = failCommandOnConnecting
   )
   
   /**

--- a/src/main/scala/scredis/Client.scala
+++ b/src/main/scala/scredis/Client.scala
@@ -46,7 +46,8 @@ class Client(
   tcpReceiveBufferSizeHint: Int = RedisConfigDefaults.IO.TCPReceiveBufferSizeHint,
   akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
   akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-  akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+  akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+  failCommandOnConnecting: Boolean =  RedisConfigDefaults.Global.FailCommandOnConnecting
 )(implicit system: ActorSystem) extends AkkaNonBlockingConnection(
   system = system,
   host = host,
@@ -62,7 +63,8 @@ class Client(
   decodersCount = 2,
   akkaListenerDispatcherPath = akkaListenerDispatcherPath,
   akkaIODispatcherPath = akkaIODispatcherPath,
-  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+  failCommandOnConnecting = failCommandOnConnecting
 ) with ConnectionCommands
   with ServerCommands
   with KeyCommands
@@ -95,7 +97,8 @@ class Client(
     tcpReceiveBufferSizeHint = config.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath = config.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath = config.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting = config.Global.FailCommandOnConnecting
   )
   
   /**
@@ -179,7 +182,8 @@ object Client {
     tcpReceiveBufferSizeHint: Int = RedisConfigDefaults.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting: Boolean =  RedisConfigDefaults.Global.FailCommandOnConnecting
   )(implicit system: ActorSystem): Client = new Client(
     host = host,
     port = port,
@@ -193,7 +197,8 @@ object Client {
     tcpReceiveBufferSizeHint = tcpReceiveBufferSizeHint,
     akkaListenerDispatcherPath = akkaListenerDispatcherPath,
     akkaIODispatcherPath = akkaIODispatcherPath,
-    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+    failCommandOnConnecting =  failCommandOnConnecting
   )
   
   /**

--- a/src/main/scala/scredis/Redis.scala
+++ b/src/main/scala/scredis/Redis.scala
@@ -32,7 +32,8 @@ class Redis private[scredis] (
   tcpReceiveBufferSizeHint: Int,
   akkaListenerDispatcherPath: String,
   akkaIODispatcherPath: String,
-  akkaDecoderDispatcherPath: String
+  akkaDecoderDispatcherPath: String,
+  failCommandOnConnecting: Boolean
 ) extends AkkaNonBlockingConnection(
   system = systemOrName match {
     case Left(system) => system
@@ -51,7 +52,8 @@ class Redis private[scredis] (
   akkaListenerDispatcherPath = akkaListenerDispatcherPath,
   akkaIODispatcherPath = akkaIODispatcherPath,
   akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
-  decodersCount = 2
+  decodersCount = 2,
+  failCommandOnConnecting = failCommandOnConnecting
 ) with ConnectionCommands
   with ServerCommands
   with KeyCommands
@@ -144,7 +146,8 @@ class Redis private[scredis] (
     actorSystemName: String = RedisConfigDefaults.IO.Akka.ActorSystemName,
     akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   ) = this(
     systemOrName = Right(actorSystemName),
     host = host,
@@ -159,7 +162,8 @@ class Redis private[scredis] (
     tcpReceiveBufferSizeHint = tcpReceiveBufferSizeHint,
     akkaListenerDispatcherPath = akkaListenerDispatcherPath,
     akkaIODispatcherPath = akkaIODispatcherPath,
-    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+    failCommandOnConnecting = failCommandOnConnecting
   )
   
   /**
@@ -181,7 +185,8 @@ class Redis private[scredis] (
     actorSystemName = config.IO.Akka.ActorSystemName,
     akkaListenerDispatcherPath = config.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath = config.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting = config.Global.FailCommandOnConnecting
   )
   
   /**
@@ -380,7 +385,8 @@ object Redis {
     actorSystemName: String = RedisConfigDefaults.IO.Akka.ActorSystemName,
     akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   ): Redis = new Redis(
     host = host,
     port = port,
@@ -395,7 +401,8 @@ object Redis {
     actorSystemName = actorSystemName,
     akkaListenerDispatcherPath = akkaListenerDispatcherPath,
     akkaIODispatcherPath = akkaIODispatcherPath,
-    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+    failCommandOnConnecting = failCommandOnConnecting
   )
   
   /**
@@ -481,7 +488,8 @@ object Redis {
     tcpReceiveBufferSizeHint: Int = RedisConfigDefaults.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath: String = RedisConfigDefaults.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath: String = RedisConfigDefaults.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   )(implicit system: ActorSystem): Redis = new Redis(
     systemOrName = Left(system),
     host = host,
@@ -496,7 +504,8 @@ object Redis {
     tcpReceiveBufferSizeHint = tcpSendBufferSizeHint,
     akkaListenerDispatcherPath = akkaListenerDispatcherPath,
     akkaIODispatcherPath = akkaIODispatcherPath,
-    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+    akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+    failCommandOnConnecting = failCommandOnConnecting
   )
   
   /**
@@ -532,7 +541,8 @@ object Redis {
     tcpReceiveBufferSizeHint = config.IO.TCPReceiveBufferSizeHint,
     akkaListenerDispatcherPath = config.IO.Akka.ListenerDispatcherPath,
     akkaIODispatcherPath = config.IO.Akka.IODispatcherPath,
-    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath
+    akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath,
+    failCommandOnConnecting = config.Global.FailCommandOnConnecting
   )
   
   /**

--- a/src/main/scala/scredis/RedisCluster.scala
+++ b/src/main/scala/scredis/RedisCluster.scala
@@ -29,7 +29,8 @@ class RedisCluster private[scredis](
     akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
     tryAgainWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.TryAgainWait,
     clusterDownWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.ClusterDownWait,
-    systemOpt:Option[ActorSystem] = None
+    systemOpt:Option[ActorSystem] = None,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   )
   extends ClusterConnection(
     nodes = nodes,
@@ -42,7 +43,8 @@ class RedisCluster private[scredis](
     akkaIODispatcherPath = akkaIODispatcherPath,
     tryAgainWait = tryAgainWait,
     clusterDownWait = clusterDownWait,
-    systemOpt = systemOpt
+    systemOpt = systemOpt,
+    failCommandOnConnecting = failCommandOnConnecting
   ) with Connection
   with ClusterCommands
   with HashCommands
@@ -77,7 +79,8 @@ class RedisCluster private[scredis](
     akkaDecoderDispatcherPath = config.IO.Akka.DecoderDispatcherPath,
     tryAgainWait = config.IO.Cluster.TryAgainWait,
     clusterDownWait = config.IO.Cluster.ClusterDownWait,
-    systemOpt = systemOpt
+    systemOpt = systemOpt,
+    failCommandOnConnecting = config.Global.FailCommandOnConnecting
   )
 
   /**
@@ -132,7 +135,8 @@ object RedisCluster {
     akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
     tryAgainWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.TryAgainWait,
     clusterDownWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.ClusterDownWait,
-    systemOpt: Option[ActorSystem] = None
+    systemOpt: Option[ActorSystem] = None,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   ) = new RedisCluster(
     nodes = nodes,
     maxRetries = maxRetries,
@@ -144,7 +148,8 @@ object RedisCluster {
     akkaIODispatcherPath = akkaIODispatcherPath,
     tryAgainWait = tryAgainWait,
     clusterDownWait = clusterDownWait,
-    systemOpt = systemOpt
+    systemOpt = systemOpt,
+    failCommandOnConnecting = failCommandOnConnecting
   )
 
 

--- a/src/main/scala/scredis/RedisConfig.scala
+++ b/src/main/scala/scredis/RedisConfig.scala
@@ -103,7 +103,7 @@ class RedisConfig(config: Config = ConfigFactory.load().getConfig("scredis")) {
     val MaxConcurrentRequestsOpt = optionally("max-concurrent-requests") {
       config.getInt("max-concurrent-requests")
     }
-    
+    val FailCommandOnConnecting = config.getBoolean("fail-command-on-connecting")
     object EncodeBufferPool {
       private implicit val config = Global.config.getConfig("encode-buffer-pool")
       val PoolMaxCapacity = config.getInt("pool-max-capacity")

--- a/src/main/scala/scredis/io/AkkaBlockingConnection.scala
+++ b/src/main/scala/scredis/io/AkkaBlockingConnection.scala
@@ -35,7 +35,8 @@ abstract class AkkaBlockingConnection(
   tcpReceiveBufferSizeHint: Int,
   akkaListenerDispatcherPath: String,
   akkaIODispatcherPath: String,
-  akkaDecoderDispatcherPath: String
+  akkaDecoderDispatcherPath: String,
+  failCommandOnConnecting:Boolean
 ) extends AbstractAkkaConnection(
   system = system,
   host = host,
@@ -71,7 +72,8 @@ abstract class AkkaBlockingConnection(
       tcpSendBufferSizeHint,
       tcpReceiveBufferSizeHint,
       akkaIODispatcherPath,
-      akkaDecoderDispatcherPath
+      akkaDecoderDispatcherPath,
+      failCommandOnConnecting
     ).withDispatcher(akkaListenerDispatcherPath),
     UniqueNameGenerator.getUniqueName(s"${nameOpt.getOrElse(s"$host-$port")}-listener-actor")
   )

--- a/src/main/scala/scredis/io/AkkaNonBlockingConnection.scala
+++ b/src/main/scala/scredis/io/AkkaNonBlockingConnection.scala
@@ -30,7 +30,8 @@ abstract class AkkaNonBlockingConnection(
   tcpReceiveBufferSizeHint: Int,
   akkaListenerDispatcherPath: String,
   akkaIODispatcherPath: String,
-  akkaDecoderDispatcherPath: String
+  akkaDecoderDispatcherPath: String,
+  failCommandOnConnecting: Boolean
 ) extends AbstractAkkaConnection(
   system = system,
   host = host,
@@ -66,7 +67,8 @@ abstract class AkkaNonBlockingConnection(
       tcpSendBufferSizeHint,
       tcpReceiveBufferSizeHint,
       akkaIODispatcherPath,
-      akkaDecoderDispatcherPath
+      akkaDecoderDispatcherPath,
+      failCommandOnConnecting
     ).withDispatcher(akkaListenerDispatcherPath),
     UniqueNameGenerator.getUniqueName(s"${nameOpt.getOrElse(s"$host-$port")}-listener-actor")
   )

--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -33,7 +33,8 @@ abstract class ClusterConnection(
     akkaDecoderDispatcherPath: String = RedisConfigDefaults.IO.Akka.DecoderDispatcherPath,
     tryAgainWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.TryAgainWait,
     clusterDownWait: FiniteDuration = RedisConfigDefaults.IO.Cluster.ClusterDownWait,
-    systemOpt:Option[ActorSystem] = None
+    systemOpt:Option[ActorSystem] = None,
+    failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting
   ) extends NonBlockingConnection with LazyLogging {
 
   private val maxHashMisses = 100
@@ -117,7 +118,7 @@ abstract class ClusterConnection(
       database = 0, nameOpt = None, decodersCount = 2,
       receiveTimeoutOpt, connectTimeout, maxWriteBatchSize, tcpSendBufferSizeHint,
       tcpReceiveBufferSizeHint, akkaListenerDispatcherPath, akkaIODispatcherPath,
-      akkaDecoderDispatcherPath
+      akkaDecoderDispatcherPath, failCommandOnConnecting
     ) {}
   }
 

--- a/src/main/scala/scredis/io/ListenerActor.scala
+++ b/src/main/scala/scredis/io/ListenerActor.scala
@@ -33,7 +33,8 @@ class ListenerActor(
   tcpSendBufferSizeHint: Int,
   tcpReceiveBufferSizeHint: Int,
   akkaIODispatcherPath: String,
-  akkaDecoderDispatcherPath: String
+  akkaDecoderDispatcherPath: String,
+  failCommandOnConnecting:Boolean
 ) extends Actor with LazyLogging {
   
   import ListenerActor._
@@ -285,7 +286,11 @@ class ListenerActor(
       isShuttingDownBeforeConnected = true
     }
     case request: Request[_] => {
-      queuedRequests.addLast(request)
+      if(failCommandOnConnecting) {
+        request.failure(RedisIOException("Trying to connect..."))
+      } else{
+        queuedRequests.addLast(request)
+      }
       if (!isConnecting) {
         reconnect()
       }

--- a/src/main/scala/scredis/io/SubscriberAkkaConnection.scala
+++ b/src/main/scala/scredis/io/SubscriberAkkaConnection.scala
@@ -52,7 +52,7 @@ abstract class SubscriberAkkaConnection(
   tcpReceiveBufferSizeHint = tcpReceiveBufferSizeHint,
   akkaListenerDispatcherPath = akkaListenerDispatcherPath,
   akkaIODispatcherPath = akkaIODispatcherPath,
-  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
 ) with SubscriberConnection {
   
   private val lock = new Semaphore(1)

--- a/src/main/scala/scredis/io/SubscriberListenerActor.scala
+++ b/src/main/scala/scredis/io/SubscriberListenerActor.scala
@@ -38,7 +38,8 @@ class SubscriberListenerActor(
   tcpSendBufferSizeHint = tcpSendBufferSizeHint,
   tcpReceiveBufferSizeHint = tcpReceiveBufferSizeHint,
   akkaIODispatcherPath = akkaIODispatcherPath,
-  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath
+  akkaDecoderDispatcherPath = akkaDecoderDispatcherPath,
+  failCommandOnConnecting = false
 ) {
   
   import SubscriberListenerActor._


### PR DESCRIPTION
Currently the non blocking client can actually block for up to `connect-timeout` seconds whenever cluster node is not responding. 
As usually connect timeout is much greater than receive, in some real time system this behavior might be unacceptable. 
I have added a config parameter `fail-command-on-connecting` that when set to `true` will fail fast all incoming requests while we are trying to connect to the node. 
This will guarantee the `receive-timeout` to be respected.