### PR TITLE
Throw exception during building transaction when operations limit reached

### DIFF
--- a/src/main/scala/scredis/commands/TransactionCommands.scala
+++ b/src/main/scala/scredis/commands/TransactionCommands.scala
@@ -40,7 +40,7 @@ trait TransactionCommands {
    * 
    * @param build the transaction block
    * @return vector containing the results of all queued commands
-   * @throws IllegalArgumentException when operations count exceeds semaphore limit defined in configuration
+    *         or failed future with IllegalArgumentException when operations count exceeds semaphore limit defined in configuration
    *
    * @since 1.2.0
    */
@@ -50,7 +50,6 @@ trait TransactionCommands {
       build(builder)
       send(builder.result())
     } catch {
-      case e: IllegalArgumentException => throw e
       case e: Throwable => Future.failed(RedisTransactionBuilderException(cause = e))
     }
   }
@@ -74,5 +73,4 @@ trait TransactionCommands {
       case e: Throwable => throw RedisTransactionBuilderException(cause = e)
     }
   }
-  
 }

--- a/src/main/scala/scredis/commands/TransactionCommands.scala
+++ b/src/main/scala/scredis/commands/TransactionCommands.scala
@@ -1,13 +1,12 @@
 package scredis.commands
 
 import scredis.TransactionBuilder
-import scredis.io.{ Connection, NonBlockingConnection, TransactionEnabledConnection }
-import scredis.protocol.requests.TransactionRequests._
 import scredis.exceptions.RedisTransactionBuilderException
+import scredis.io.{Connection, NonBlockingConnection, TransactionEnabledConnection}
+import scredis.protocol.requests.TransactionRequests._
 
-import scala.util.Try
 import scala.concurrent.Future
-import scredis.TransactionBuilder
+import scala.util.Try
 
 /**
  * This trait implements transaction commands.
@@ -41,6 +40,7 @@ trait TransactionCommands {
    * 
    * @param build the transaction block
    * @return vector containing the results of all queued commands
+   * @throws IllegalArgumentException when operations count exceeds semaphore limit defined in configuration
    *
    * @since 1.2.0
    */
@@ -50,6 +50,7 @@ trait TransactionCommands {
       build(builder)
       send(builder.result())
     } catch {
+      case e: IllegalArgumentException => throw e
       case e: Throwable => Future.failed(RedisTransactionBuilderException(cause = e))
     }
   }
@@ -59,6 +60,7 @@ trait TransactionCommands {
    * 
    * @param build the transaction block
    * @return whatever 'build' returns
+   * @throws RedisTransactionBuilderException when exception occurs during building transaction
    *
    * @since 1.2.0
    */

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -11,3 +11,5 @@ akka {
   }
   
 }
+
+scredis.global.max-concurrent-requests = 300

--- a/src/test/scala/scredis/commands/TransactionCommandsSpec.scala
+++ b/src/test/scala/scredis/commands/TransactionCommandsSpec.scala
@@ -57,6 +57,15 @@ class TransactionCommandsSpec extends WordSpec
         client.inTransaction(_ => ()).futureValue should be (empty)
       }
     }
+    "commands list exceed semaphore limit" should {
+      "throw exception" in {
+        a [IllegalArgumentException] should be thrownBy {
+          client.inTransaction { tx =>
+            (1 to 400).map(_ => tx.set("OVERFLOW", 1))
+          }
+        }
+      }
+    }
     "all commands are valid" should {
       "succeed" taggedAs (V120) in {
         client.set("STR", SomeValue)


### PR DESCRIPTION
Scredis provides pool of permits to execute operations to redis server.
Number of permits is configured by configuration variable `scredis.global.max-concurrent-requests = 30000`
When we create a transaction we can generate more requests that a possible maximum of operations.
This issue was raised in #45 .
From now on building a transaction can throw an `IllegalArgumentException` if number of requests exceeds `max-concurrent-requests` parameter.