### PR TITLE
support for redis cluster password

### DIFF
--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -114,7 +114,7 @@ abstract class ClusterConnection(
     val system = systemOpt.getOrElse(ActorSystem(UniqueNameGenerator.getUniqueName(systemName)))
 
     new AkkaNonBlockingConnection(
-      system = system, host = server.host, port = server.port, passwordOpt = None,
+      system = system, host = server.host, port = server.port, passwordOpt = passwordOpt = passwordOpt,,
       database = 0, nameOpt = None, decodersCount = 2,
       receiveTimeoutOpt, connectTimeout, maxWriteBatchSize, tcpSendBufferSizeHint,
       tcpReceiveBufferSizeHint, akkaListenerDispatcherPath, akkaIODispatcherPath,


### PR DESCRIPTION
Made change to pass config password while using redis cluster. For some other reasons, we were not able to deploy to our production evn. So I am afraid that it has not been thoroughly tested. 