### PR TITLE
Trying a different server in a cluster should not count as a retry

### DIFF
--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -193,7 +193,7 @@ abstract class ClusterConnection(
           val nextTriedServers = triedServers + server
           // try any server that isn't one we tried already
           connections.keys.find { s => !nextTriedServers.contains(s)  } match {
-            case Some(nextServer) => send(request, nextServer, nextTriedServers, retry - 1, remainingTimeout, Option(err))
+            case Some(nextServer) => send(request, nextServer, nextTriedServers, retry, remainingTimeout, Option(err))
             case None => Future.failed(RedisIOException("No valid connection available.", err))
           }
       }


### PR DESCRIPTION
There is no need to consider trying a different node in the cluster as a "retry" when encountering a `RedisIOException`. Once the request has tried all the nodes in the cluster it will fail anyways (`ClusterConnection` line 197).

The current approach is problematic during a significant live scale down of the cluster (e.g. from 50 => 5 nodes). In that situation the odds of trying 4 nodes that are no longer available is very high and we want to get the connections updated as soon as possible.