### PR TITLE
RedisCluster.quit() blocked

### DIFF
--- a/src/main/scala/scredis/io/AbstractAkkaConnection.scala
+++ b/src/main/scala/scredis/io/AbstractAkkaConnection.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.LazyLogging
 import scredis.protocol.{AuthConfig, Request}
 import scredis.protocol.requests.ConnectionRequests.{Auth, Quit, Select}
 import scredis.protocol.requests.ServerRequests.{ClientSetName, Shutdown}
-import scredis.util.UniqueNameGenerator
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -60,11 +59,11 @@ abstract class AbstractAkkaConnection(
   protected def getNameOpt: Option[String] = nameOpt
   
   protected def watchTermination(): Unit = system.actorOf(
-      Props(
-        classOf[WatchActor],
-        listenerActor,
-        shutdownLatch
-      )
+    Props(
+      classOf[WatchActor],
+      listenerActor,
+      shutdownLatch
+    )
   )
   
   /**

--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -155,7 +155,7 @@ abstract class ClusterConnection(
       }
 
       val watchActorRef = watchTermination()
-      watchActorRefList = watchActorRefList.append((server, watchActorRef))
+      watchActorRefList.append((server, watchActorRef))
     }
   }
 

--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -1,6 +1,6 @@
 package scredis.io
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.ActorSystem
 import com.typesafe.scalalogging.LazyLogging
 import scredis.exceptions._
 import scredis.protocol._
@@ -9,7 +9,6 @@ import scredis.protocol.requests.ConnectionRequests.Quit
 import scredis.util.UniqueNameGenerator
 import scredis.{ClusterSlotRange, RedisConfigDefaults, Server}
 
-import scala.collection.mutable.HashMap
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}

--- a/src/main/scala/scredis/io/ListenerActor.scala
+++ b/src/main/scala/scredis/io/ListenerActor.scala
@@ -277,6 +277,7 @@ class ListenerActor(
       request.success(())
       failAllQueuedRequests(RedisIOException("Connection has been shutdown by QUIT command"))
       isShuttingDownBeforeConnected = true
+      shutdown()
     case request: Request[_] =>
       if(failCommandOnConnecting) {
         request.failure(RedisIOException("Trying to connect..."))


### PR DESCRIPTION
the bad case scenario:
1. the RedisCluster is not initialized successfully all the time
2. the RedisCluster initialize ok, but it is disconnected after a while

finally,  RedisCluster.quit() will be blocked.

I track the issue and get root cause, here I provide my code implementation, thanks for review.