### PR TITLE
Remove stray comment line

### DIFF
--- a/src/main/scala/scredis/commands/KeyCommands.scala
+++ b/src/main/scala/scredis/commands/KeyCommands.scala
@@ -247,7 +247,6 @@ trait KeyCommands { self: NonBlockingConnection =>
    * Returns a random key from the keyspace.
    *
    * @return the random key or $none when the database is empty
-   * associated timeout
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
Applying this PR will remove a stray comment line, probably an old copy/paste-thing.