### PR TITLE
Use execution context of provided ActorSystem if provided, default to global if not provided

### DIFF
--- a/src/main/scala/scredis/RedisCluster.scala
+++ b/src/main/scala/scredis/RedisCluster.scala
@@ -63,7 +63,7 @@ class RedisCluster private[scredis](
   //with SubscriberCommands
 {
   override implicit val dispatcher: ExecutionContext =
-    ExecutionContext.Implicits.global // TODO perhaps implement our own
+    systemOpt.map(_.dispatcher).getOrElse(ExecutionContext.Implicits.global) // TODO perhaps implement our own for the default
 
   /**
     * Constructs a $redisCluster instance from a [[scredis.RedisConfig]].

--- a/src/main/scala/scredis/Transaction.scala
+++ b/src/main/scala/scredis/Transaction.scala
@@ -3,10 +3,10 @@ package scredis
 import scredis.protocol.Request
 import scredis.protocol.requests.TransactionRequests.{Exec, Multi}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
-private[scredis] final case class Transaction (requests: Seq[Request[_]]) {
+private[scredis] final case class Transaction (requests: Seq[Request[_]])(implicit ec: ExecutionContext) {
   val execRequest = Exec(requests.map(_.decode))
   private val future = execRequest.future
   

--- a/src/main/scala/scredis/io/ClusterConnection.scala
+++ b/src/main/scala/scredis/io/ClusterConnection.scala
@@ -9,9 +9,8 @@ import scredis.protocol.requests.ConnectionRequests.Quit
 import scredis.util.UniqueNameGenerator
 import scredis.{ClusterSlotRange, RedisConfigDefaults, Server}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 
 /**
  * The connection logic for a whole Redis cluster. Handles redirection and sharding logic as specified in
@@ -38,6 +37,7 @@ abstract class ClusterConnection(
     failCommandOnConnecting: Boolean = RedisConfigDefaults.Global.FailCommandOnConnecting,
     authOpt: Option[AuthConfig] = RedisConfigDefaults.Config.Redis.AuthOpt
   ) extends NonBlockingConnection with LazyLogging {
+  implicit val ec: ExecutionContext = systemOpt.map(_.dispatcher).getOrElse(ExecutionContext.Implicits.global)
 
   // Int parameter - count number of errors for given connection.
   // When defined threshold is reached connection to this server is removed and no longer used.

--- a/src/main/scala/scredis/io/DecoderActor.scala
+++ b/src/main/scala/scredis/io/DecoderActor.scala
@@ -72,7 +72,7 @@ class DecoderActor(subscriptionOption: Option[Subscription]) extends Actor with 
             case Right(Right(message)) =>
               subscriptionOption match {
                 case Some(subscription) =>
-                  Future {subscription.apply(message)}(ExecutionContext.global)
+                  Future {subscription.apply(message)}(context.dispatcher)
                 case None =>
                   log.error("Received SubscribePartition without any subscription")
               }


### PR DESCRIPTION
Library code typically uses a provided ExecutionContext rather than using a custom or the global, as end users might have custom logic in their own ExecutionContext. One common use case is propagating normally thread-local MDC values across Future boundaries. 