### PR TITLE
Create unresolved InetSocketAddress for Redis remote

### DIFF
--- a/src/main/scala/scredis/io/ListenerActor.scala
+++ b/src/main/scala/scredis/io/ListenerActor.scala
@@ -43,7 +43,7 @@ class ListenerActor(
     case e: Exception => SupervisorStrategy.Stop
   }
   
-  private val remote = new InetSocketAddress(host, port)
+  private val remote = InetSocketAddress.createUnresolved(host, port)
   
   private var remainingByteStringOpt: Option[ByteString] = None
   private var initializationRequestsCount = 0


### PR DESCRIPTION
This change causes Scredis to re-resolve the Redis host name, should it
need to reconnect to the Redis host.  This is helpful if a primary is
failing and a secondary is promoted to become the new primary.  If the
InetSocketAddress is already resolved here Scredis will continuously
attempt to re-connect to the old master's IP address.

Co-Authored-By: Ananya Deb <67650258+AnanyaDeb@users.noreply.github.com>