### PR TITLE
Add SMISMEMBER command

### DIFF
--- a/run-redis-cluster.sh
+++ b/run-redis-cluster.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -it --name redis -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 grokzen/redis-cluster:6.0.1
+docker run --rm -it --name redis -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 grokzen/redis-cluster:6.2.0

--- a/src/main/scala/scredis/commands/SetCommands.scala
+++ b/src/main/scala/scredis/commands/SetCommands.scala
@@ -114,7 +114,23 @@ trait SetCommands { self: NonBlockingConnection =>
   def sIsMember[W: Writer](key: String, member: W): Future[Boolean] = send(
     SIsMember(key, member)
   )
-  
+
+  /**
+   * Checks existence of members in a set.
+   *
+   * @param key set key
+   * @param members values to be tested
+   * @return list representing the membership of the given values, in the same order as they are requested where $true
+   *         means the value is a member of the set stored at key, $false otherwise
+   * @throws $e if key contains a value that is not a set
+   *
+   * @since 6.2.0
+   * @see [[https://redis.io/commands/smismember]]
+   */
+  def sMIsMember[W: Writer](key: String, members: W*): Future[Seq[Boolean]] = send(
+    SMIsMember(key, members: _*)
+  )
+
   /**
    * Returns all the members of a set.
    *

--- a/src/main/scala/scredis/protocol/requests/SetRequests.scala
+++ b/src/main/scala/scredis/protocol/requests/SetRequests.scala
@@ -16,6 +16,7 @@ object SetRequests {
   object SInterStore extends Command("SINTERSTORE") with WriteCommand
   object SIsMember extends Command("SISMEMBER")
   object SMembers extends Command("SMEMBERS")
+  object SMIsMember extends Command("SMISMEMBER")
   object SMove extends Command("SMOVE") with WriteCommand
   object SPop extends Command("SPOP") with WriteCommand
   object SRandMember extends Command("SRANDMEMBER")
@@ -83,7 +84,7 @@ object SetRequests {
       case i: IntegerResponse => i.toBoolean
     }
   }
-  
+
   case class SMembers[R: Reader](key: String) extends Request[Set[R]](SMembers, key) with Key {
     override def decode = {
       case a: ArrayResponse => a.parsed[R, Set] {
@@ -91,7 +92,19 @@ object SetRequests {
       }
     }
   }
-  
+
+  case class SMIsMember[W: Writer](key: String, members: W*) extends Request[Seq[Boolean]](
+    SMIsMember, key +: members: _*
+  ) with Key {
+    override def decode = {
+      case a: ArrayResponse =>
+        val replies = a.parsed[Boolean, Seq] {
+          case i: IntegerResponse => i.toBoolean
+        }
+        replies
+    }
+  }
+
   case class SMove[W: Writer](
     source: String, destination: String, member: W
   ) extends Request[Boolean](

--- a/src/test/scala/scredis/commands/SetCommandsSpec.scala
+++ b/src/test/scala/scredis/commands/SetCommandsSpec.scala
@@ -362,6 +362,30 @@ class SetCommandsSpec extends AnyWordSpec
     }
   }
 
+  SMIsMember.toString when {
+    "the key does not exist" should {
+      "return false" taggedAs (V100) in {
+        client.sMIsMember("SET", Seq("A"):_*).futureValue should be(Seq(false))
+      }
+    }
+    "the key does not contain a set" should {
+      "return an error" taggedAs (V100) in {
+        a[RedisErrorResponseException] should be thrownBy {
+          client.sMIsMember("HASH", Seq("A"):_*).!
+        }
+      }
+    }
+    "the set contains some elements" should {
+      "return the correct value" taggedAs (V100) in {
+        client.sAdd("SET", "1")
+        client.sAdd("SET", "2")
+        client.sAdd("SET", "3")
+        client.sMIsMember("SET", Seq("A", "1", "2", "3"):_*).futureValue should be(Seq(false, true, true, true))
+        client.del("SET")
+      }
+    }
+  }
+
   SMembers.toString when {
     "the key does not exist" should {
       "return None" taggedAs (V100) in {


### PR DESCRIPTION
Applying this PR will add the SMISMEMBER command, which was introduced in Redis 6.2. I didn't add the tests yet, because I think that requires some work on the CI build first.